### PR TITLE
Fix validation

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -58,7 +58,10 @@ jobs:
       - name: Install dependencies using poetry
         if: steps.python_cache.outputs.cache-hit != 'true'
         run: |
-          pip install poetry
+          # NOTE: installing poetry 1.1.15 explicitly is a temporary fix
+          # for https://github.com/ItsDrike/AMCEF/runs/8295251991?check_suite_focus=true#step:6:209
+          # It seems like poetry 1.2.0 has changed some core logic causing pip to fail installation
+          pip install poetry==1.1.15
           poetry install
 
       # Cache pre-commit environment


### PR DESCRIPTION
Fix a critical issue in workflows caused by a recent poetry update.

Note: This is only a quick temporary fix, as it just sets the poetry version to the older functional one. A full fix working with poetry 1.2.0 should be done afterwards for a more long term solution.